### PR TITLE
initial 0.1.51

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.5.0" %}
+{% set version = "0.1.51" %}
 
 package:
   name: aws-c-s3
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/awslabs/aws-c-s3/archive/v{{ version }}.tar.gz
-  sha256: 8289b2c560ebf49fe9b3d163ebcd284a2083976637d9aa9f8d5e59e0d19836fb
+  sha256: 46b8ef3d42a1973ffcd17ea25540baecc4b4e35216a276c7f93bc8e8e9dc3d9e
 
 build:
   number: 0
@@ -17,15 +17,15 @@ requirements:
   build:
     - cmake
     - {{ compiler('c') }}
-    - ninja
+    - ninja-base
   host:
-    - aws-checksums
-    - aws-c-auth
-    - aws-c-cal
-    - aws-c-common
-    - aws-c-http
-    - aws-c-io
-    - openssl  # [linux]
+    - aws-checksums 0.1.13
+    - aws-c-auth 0.6.19
+    - aws-c-cal 0.5.20
+    - aws-c-common 0.8.5
+    - aws-c-http 0.6.25
+    - aws-c-io 0.13.10
+    - openssl {{ openssl }}  # [linux]
 
 test:
   commands:
@@ -40,6 +40,10 @@ about:
   license_family: Apache
   license_file: LICENSE
   summary: C99 library implementation for communicating with the S3 service.
+  description: |
+    The AWS-C-S3 library is an asynchronous AWS S3 client focused on maximizing throughput and network utilization.
+  doc_url: https://github.com/awslabs/aws-c-s3
+  dev_url: https://github.com/awslabs/aws-c-s3
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
aws-c-s3 0.1.51

Destination channel: defaults

Links
[{ticket_number}](https://anaconda.atlassian.net/browse/PKG-3969)
[Upstream repository](https://github.com/awslabs/aws-c-auth/releases/tag/v0.1.51)
dependency for aws-crt 0.18.16 -> aws-sdk-cpp 1.10.55 -> arrow-cpp 14.0.1 -> pyarrow 14.0.1 which would address CVE