### PR TITLE
Update version to 0.12.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aws-c-s3" %}
-{% set version = "0.11.3" %}
+{% set version = "0.12.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: b8350a10050015493345453167d619f1b407c4970fa3fe5aaaf2b42ab93b7b6b
+  sha256: 1a8a8ceda0585d52028a1f3daa5861f924e7d8d2f6a17bec05813dc0b74d6eed
 
 build:
   number: 0
@@ -21,7 +21,7 @@ requirements:
     - cmake
     - ninja-base
   host:
-    - aws-checksums 0.2.8
+    - aws-checksums 0.2.10
     - aws-c-auth 0.9.4
     - aws-c-cal 0.9.13
     - aws-c-common 0.12.6


### PR DESCRIPTION
aws-c-s3 0.12.0

**Destination channel:**  defaults

### Links

- [PKG-13173](https://anaconda.atlassian.net/browse/PKG-13173) 
- [Upstream repository](https://github.com/awslabs/aws-c-s3/tree/v0.12.0)

### Explanation of changes:
- New version number
- Updated dependencies


[PKG-13173]: https://anaconda.atlassian.net/browse/PKG-13173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ