### PR TITLE
aws-c-s3 0.12.0 - rebuild (new dependencies)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-channels:
-  - https://staging.continuum.io/preprod-pbp/fs/aws-c-io-feedstock/pr7/928beff
-  - https://staging.continuum.io/preprod-pbp/fs/aws-c-compression-feedstock/pr6/8a902d3
-  - https://staging.continuum.io/preprod-pbp/fs/aws-c-http-feedstock/pr7/c623fb1
-  - https://staging.continuum.io/preprod-pbp/fs/aws-c-auth-feedstock/pr7/15f9a47

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+channels:
+  - https://staging.continuum.io/preprod-pbp/fs/aws-c-io-feedstock/pr7/928beff
+  - https://staging.continuum.io/preprod-pbp/fs/aws-c-compression-feedstock/pr6/8a902d3
+  - https://staging.continuum.io/preprod-pbp/fs/aws-c-http-feedstock/pr7/c623fb1
+  - https://staging.continuum.io/preprod-pbp/fs/aws-c-auth-feedstock/pr7/15f9a47

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 1a8a8ceda0585d52028a1f3daa5861f924e7d8d2f6a17bec05813dc0b74d6eed
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("aws-c-s3", max_pin="x.x.x") }}
 
@@ -22,11 +22,11 @@ requirements:
     - ninja-base
   host:
     - aws-checksums 0.2.10
-    - aws-c-auth 0.9.4
+    - aws-c-auth 0.10.1
     - aws-c-cal 0.9.13
     - aws-c-common 0.12.6
-    - aws-c-http 0.10.7
-    - aws-c-io 0.23.3
+    - aws-c-http 0.10.13
+    - aws-c-io 0.26.3
     - openssl {{ openssl }}  # [linux]
 
 test:


### PR DESCRIPTION
aws-c-s3 0.12.0 

**Destination channel:** Defaults

### Links

- [PKG-13655]
- dev_url:        https://github.com/awslabs/aws-c-s3
- conda_forge:    https://github.com/conda-forge/aws-c-s3-feedstock
- pypi:           https://pypi.org/project/aws-c-s3/0.12.0
- pypi inspector: https://inspector.pypi.io/project/aws-c-s3/0.12.0

### Explanation of changes:

- new version number


[PKG-13655]: https://anaconda.atlassian.net/browse/PKG-13655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ