### PR TITLE
aws-c-s3 0.12.5 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aws-c-s3" %}
-{% set version = "0.12.0" %}
+{% set version = "0.12.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 1a8a8ceda0585d52028a1f3daa5861f924e7d8d2f6a17bec05813dc0b74d6eed
+  sha256: 1d039ef1fb7df6696757b3fe219ce03a52c244c79e38d637c49d99b4f5871e14
 
 build:
   number: 1
@@ -22,10 +22,10 @@ requirements:
     - ninja-base
   host:
     - aws-checksums 0.2.10
-    - aws-c-auth 0.10.1
-    - aws-c-cal 0.9.13
-    - aws-c-common 0.12.6
-    - aws-c-http 0.10.13
+    - aws-c-auth 0.10.3
+    - aws-c-cal 0.9.14
+    - aws-c-common 0.14.0
+    - aws-c-http 0.11.0
     - aws-c-io 0.26.3
     - openssl {{ openssl }}  # [linux]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "0.12.5" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -10,7 +10,7 @@ source:
   sha256: 1d039ef1fb7df6696757b3fe219ce03a52c244c79e38d637c49d99b4f5871e14
 
 build:
-  number: 1
+  number: 0
   run_exports:
     - {{ pin_subpackage("aws-c-s3", max_pin="x.x.x") }}
 


### PR DESCRIPTION
aws-c-s3 0.12.5 

**Destination channel:** Defaults

### Links

- [PKG-15442]
- dev_url:        https://github.com/awslabs/aws-c-s3/tree/v0.12.5
- conda_forge:    https://github.com/conda-forge/aws-c-s3-feedstock
- pypi:           None
- pypi inspector: None

### Explanation of changes:

- new version number


[PKG-15442]: https://anaconda.atlassian.net/browse/PKG-15442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ